### PR TITLE
Replaced legacy mysql real_escape_string

### DIFF
--- a/import.php
+++ b/import.php
@@ -178,7 +178,7 @@ if($file != "" && isset($mysqlInfo))
 		wp2anchor_log("Connected to the database: " . $mysqlInfo["database"]);
 
 		//Set prefix
-		$prefix = mysql_real_escape_string($_POST['prefix']);
+		$prefix = $mysql->real_escape_string($_POST['prefix']);
 
 		//Truncate tables we need to override
 		if(!@$mysql->query("TRUNCATE TABLE `" . $prefix . "categories`") ||


### PR DESCRIPTION
The import currently uses the the non-MySQLi `mysql_real_escape_string`, which sometimes causes issues. Specifically, I got the error "Can't connect to local MySQL server through socket '/No-MySQL-hostname-was-specified' (2), in spite of actually being connected to the database.

I'm not sure how widespread this problem is, but I noticed a few users complaining in forums. I've switched to the newer MySQLi `real_escape_string`, which is the preferred way of doing this.
